### PR TITLE
Add some forced cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-catalog.yaml
+++ b/.github/workflows/build-catalog.yaml
@@ -54,6 +54,9 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
+      - name: Force cleanup of docker
+        run: sudo docker rm -f $(docker ps -aq)
+
       # Example: Pushes the image quay.io/redhat-best-practices-for-k8s/qe-custom-catalog:v4.14-latest
       # The idea being that we want to rebuild the images daily, but apply our custom catalog settings as well.
       - name: Build Catalog Image(s)


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `.github/workflows/build-catalog.yaml` file by adding a step to ensure Docker containers are forcefully cleaned up before building catalog images.

Workflow improvement:

* [`.github/workflows/build-catalog.yaml`](diffhunk://#diff-3f0294095375a42f17d3528d55d00338ec2edac2c96a8c67659cb8d4808cf796R57-R59): Added a new step named "Force cleanup of docker" to remove all Docker containers (`docker rm -f $(docker ps -aq)`) to prevent potential conflicts during the build process.