### PR TITLE
ci: pin ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-catalog.yaml
+++ b/.github/workflows/build-catalog.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build-catalog-images:
     if: github.repository_owner == 'redhat-best-practices-for-k8s'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test-build-catalog-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Pin `ubuntu-latest` to `ubuntu-24.04` in all GitHub Actions workflows

Prevents unexpected behavior changes when GitHub updates the `ubuntu-latest` label.
Tracked by [CNFCERT-1419](https://redhat.atlassian.net/browse/CNFCERT-1419).